### PR TITLE
Do not set settings when creating connections

### DIFF
--- a/src/Database/PostgreSQL/Simple/Internal.hs
+++ b/src/Database/PostgreSQL/Simple/Internal.hs
@@ -235,11 +235,11 @@ connectPostgreSQL connstr = do
           connectionObjects <- newMVar (IntMap.empty)
           connectionTempNameCounter <- newIORef 0
           let wconn = Connection{..}
-          version <- PQ.serverVersion conn
-          let settings
-                | version < 80200 = "SET datestyle TO ISO;SET client_encoding TO UTF8"
-                | otherwise       = "SET datestyle TO ISO;SET client_encoding TO UTF8;SET standard_conforming_strings TO on"
-          _ <- execute_ wconn settings
+          -- version <- PQ.serverVersion conn
+          -- let settings
+          --       | version < 80200 = "SET datestyle TO ISO;SET client_encoding TO UTF8"
+          --       | otherwise       = "SET datestyle TO ISO;SET client_encoding TO UTF8;SET standard_conforming_strings TO on"
+          -- _ <- execute_ wconn settings
           return wconn
       _ -> do
           msg <- maybe "connectPostgreSQL error" id <$> PQ.errorMessage conn


### PR DESCRIPTION
Setting session-level options causes pinning issues with RDS Proxy.

This is a temporary change to test a fix for issues we're having with RDS Proxy pinning connections, which causes significantly higher RAM usage in Postgres. Once we validate that this fixes it, we'll create a non-breaking change and try to get it merged upstream into `postgresql-simple`.